### PR TITLE
Support linux

### DIFF
--- a/microbat/src/main/microbat/util/IResourceUtils.java
+++ b/microbat/src/main/microbat/util/IResourceUtils.java
@@ -83,7 +83,13 @@ public class IResourceUtils {
 			ECLIPSE_ROOT_DIR = dirRoot.getAbsolutePath();
 			DROPINS_DIR = ECLIPSE_ROOT_DIR + File.separator + "dropins";
 		} else {
-			/** TODO Linux */
+			/**
+			 * Under installation with tar file, root path is ../eclipse,
+			 * launcher file is ./eclipse, dropins at ./dropins
+			 */
+			dirRoot = new File(eclipseExecutablePath);
+			ECLIPSE_ROOT_DIR = dirRoot.getAbsolutePath();
+			DROPINS_DIR = ECLIPSE_ROOT_DIR + File.separator + "dropins";
 		}
 		File dropinsDir = new File(DROPINS_DIR);
 		if (!dropinsDir.exists() && !dropinsDir.isDirectory()) {


### PR DESCRIPTION
Logic to obtain `/dropins` directory is not implemented in linux.

This PR will set `ECLIPSE_ROOT_DIR` and `DROPINS_DIR` if os detected is linux accordingly, assuming directory structure is as such:
```
committers-202x-xx/
├─ eclipse/
│  ├─ dropins/
│  ├─ eclipse* (executable)
│  ├─ configurations/
│  ├─ eclipse.ini
```