### PR TITLE
Disable testmode for Premain

### DIFF
--- a/microbat_instrumentator/src/main/microbat/instrumentation/Premain.java
+++ b/microbat_instrumentator/src/main/microbat/instrumentation/Premain.java
@@ -24,7 +24,7 @@ import microbat.instrumentation.utils.FileUtils;
 public class Premain {
 	public static final String INSTRUMENTATION_STANTDALONE_JAR = "instrumentator_agent_v02.jar";
 	private static final String SAV_JAR = "sav.commons.simplified.jar";
-	private static boolean testMode = true;
+	private static boolean testMode = false;
 
 	public static void premain(String agentArgs, Instrumentation inst) throws Exception {
 		long vmStartupTime = System.currentTimeMillis() - ManagementFactory.getRuntimeMXBean().getStartTime();


### PR DESCRIPTION
When Premain is in testmode, it will always re-extract sav.commons.simplified.jar and instrumentator_agent_v02.jar.
This leads to crashes when running the instrumentator.jar in multiple threads, as the files are being overwritten.
Turning off testMode fixes this issue.