### PR TITLE
Add stubs for Eclipse App Singletons

### DIFF
--- a/microbat/src/main/microbat/Activator.java
+++ b/microbat/src/main/microbat/Activator.java
@@ -28,7 +28,16 @@ public class Activator extends AbstractUIPlugin {
 	 */
 	public Activator() {
 	}
-
+	
+	/**
+	 * This is to stub the plugin variable, such that the code does not have to run as an Eclipse Application. @see microbat.ActivatorStub for an example.
+	 * (Previously, plugin variable was always null if run as an Java Application, resulting in NullPointerException)
+	 * @param activator
+	 */
+	public void setItselfAsPlugin() {
+		plugin = this;
+	}
+	
 	/*
 	 * (non-Javadoc)
 	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)

--- a/microbat/src/main/microbat/ActivatorStub.java
+++ b/microbat/src/main/microbat/ActivatorStub.java
@@ -1,0 +1,17 @@
+package microbat;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+
+public class ActivatorStub extends Activator {
+	private final IPreferenceStore preferenceStore;
+	
+	public ActivatorStub(IPreferenceStore preferenceStore) {
+		super();
+		this.preferenceStore = preferenceStore;
+	}
+	
+	@Override
+	public IPreferenceStore getPreferenceStore() {
+		return preferenceStore;
+	}
+}

--- a/microbat/src/main/microbat/util/ConsoleUtils.java
+++ b/microbat/src/main/microbat/util/ConsoleUtils.java
@@ -14,27 +14,36 @@ import org.eclipse.ui.console.MessageConsoleStream;
  *
  */
 public class ConsoleUtils {
-	 static MessageConsole console = null;
-	 static MessageConsoleStream consoleStream = null;
-	 static IConsoleManager consoleManager = null;
-	 static final String CONSOLE_NAME = "DebugConsole";
-	 
-	 private static void initConsole() {
-	    	
-	    	console = new MessageConsole(CONSOLE_NAME, null);	    	
-	    	consoleManager = ConsolePlugin.getDefault().getConsoleManager();
-	    	consoleManager.addConsoles(new IConsole[] { console });
-	    	consoleStream = console.newMessageStream();
-	 }
+	static MessageConsole console = null;
+	static MessageConsoleStream consoleStream = null;
+	static IConsoleManager consoleManager = null;
+	static final String CONSOLE_NAME = "DebugConsole";
 
-	    public static void printMessage(String message) {
-	        if (message != null) {
-	            if (console == null) {
-	                initConsole();
-	            }
-	            consoleManager.showConsoleView(console);
-	            consoleStream.print(message + "\n");
-	        }
-			
-	    }
+	private static ConsoleUtils singleton = new ConsoleUtils();
+
+	public void setItselfAsSingleton() {
+		singleton = this;
+	}
+
+	protected void initConsole() {
+		console = new MessageConsole(CONSOLE_NAME, null);
+		consoleManager = ConsolePlugin.getDefault().getConsoleManager();
+		consoleManager.addConsoles(new IConsole[] { console });
+		consoleStream = console.newMessageStream();
+	}
+
+	public static void printMessage(String message) {
+		if (message != null) {
+			if (console == null) {
+				singleton.initConsole();
+			}
+			singleton.printMessageInstance(message);
+		}
+
+	}
+	
+	protected void printMessageInstance(String message) {
+		consoleManager.showConsoleView(console);
+		consoleStream.print(message + "\n");
+	}
 }

--- a/microbat/src/main/microbat/util/ConsoleUtilsStub.java
+++ b/microbat/src/main/microbat/util/ConsoleUtilsStub.java
@@ -1,0 +1,16 @@
+package microbat.util;
+
+public class ConsoleUtilsStub extends ConsoleUtils {
+	
+	@Override
+	protected void initConsole() {
+		// NOOP
+	}
+	
+	@Override
+	protected void printMessageInstance(String message) {
+        if (message != null) {
+        	System.out.println(message);
+        }
+    }
+}


### PR DESCRIPTION
# Description
When running in an Eclipse Application code as an Java Application,  `NullPointerException`s occured when calling methods on the singletons `microbat.utils.ConsoleUtils` and `microbat.Activator`.

# Modification
- New methods were added to allow overriding (`setItselfAsSingleton` and `setItselfAsPlugin`) the singletons.
- Stubs for the 2 classes were created. ( `microbat.utils.ConsoleUtilsStub` and `microbat.ActivatorStub`)

# Example Usage:
```
ConsoleUtils consoleUtilsStub = new ConsoleUtilsStub();
consoleUtilsStub.setItselfAsSingleton();
```
Now any method call to `ConsoleUtils` e.g. `ConsoleUtils.printMessage("message")`, will use methods inside `ConsoleUtilStub`